### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Django
 feincms3[all]
 psycopg2
 pytz
+django-versatileimagefield

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django
+Django<2
 feincms3[all]
 psycopg2
 pytz


### PR DESCRIPTION
without this I'll get:

```
Traceback (most recent call last):
  File "./manage.py", line 10, in <module>
    execute_from_command_line(sys.argv)
  File "/home/elmcrest/.virtualenvs/rblog/lib/python3.6/site-packages/django/core/management/__init__.py", line 371, inexecute_from_command_line
    utility.execute()
  File "/home/elmcrest/.virtualenvs/rblog/lib/python3.6/site-packages/django/core/management/__init__.py", line 347, inexecute
    django.setup()
  File "/home/elmcrest/.virtualenvs/rblog/lib/python3.6/site-packages/django/__init__.py", line 24, in setup
    apps.populate(settings.INSTALLED_APPS)
  File "/home/elmcrest/.virtualenvs/rblog/lib/python3.6/site-packages/django/apps/registry.py", line 89, in populate
    app_config = AppConfig.create(entry)
  File "/home/elmcrest/.virtualenvs/rblog/lib/python3.6/site-packages/django/apps/config.py", line 90, in create
    module = import_module(entry)
  File "/home/elmcrest/.virtualenvs/rblog/lib/python3.6/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 994, in _gcd_import
  File "<frozen importlib._bootstrap>", line 971, in _find_and_load
  File "<frozen importlib._bootstrap>", line 953, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'versatileimagefield'
```
once installed, migration works fine again