### PR TITLE
simplify requirements (remove PostgreSQL dependency)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,10 +13,8 @@ Setup a virtualenv::
     . venv/bin/activate
     pip install -r requirements.txt
 
-Create the database and maybe adapt the connection parameters
-in ``app/settings.py``::
-
-    createdb feincms3_example
+Maybe adapt the database connection parameters in ``app/settings.py``,
+if you don’t want to use SQLite.
 
 Run migrations and create a superuser::
 

--- a/app/settings.py
+++ b/app/settings.py
@@ -91,8 +91,8 @@ WSGI_APPLICATION = 'app.wsgi.application'
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.postgresql',
-        'NAME': 'feincms3_example',
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': 'db.sqlite3',
     }
 }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-Django
+Django>=2.2,<3.0
 feincms3[all]
-psycopg2-binary


### PR DESCRIPTION
Since FeinCMS3 doesn’t use CTE any more, the PostgreSQL dependency doesn’t make sense. An example project should be as easy as possible.